### PR TITLE
01 - Add a header image to the homepage

### DIFF
--- a/config/image-formats.xml
+++ b/config/image-formats.xml
@@ -5,16 +5,14 @@
 
     <!-- See: http://docs.sulu.io/en/latest/book/image-formats.html how to define image-formats -->
 
-    <!--
-    <format key="300x">
+    <format key="x400">
         <meta>
-            <title lang="en">Example Image</title>
-            <title lang="de">Beispielbild</title>
+            <title lang="en">Header Image</title>
+            <title lang="de">Titelbild</title>
         </meta>
 
-        <scale x="300"/>
+        <scale y="400"/>
     </format>
-    -->
 
     <format key="1920x">
         <meta>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -36,6 +36,17 @@
             <tag name="sulu.rlp"/>
         </property>
 
+        <property name="headerImage" type="single_media_selection">
+            <meta>
+                <title lang="en">Header image</title>
+                <title lang="de">Titelbild</title>
+            </meta>
+
+            <params>
+                <param name="types" value="image"/>
+            </params>
+        </property>
+
         <property name="article" type="text_editor">
             <meta>
                 <title lang="en">Article</title>

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -3,6 +3,9 @@
 {% block content %}
     <section class="jumbotron text-center">
         <div class="container">
+            {% if content.headerImage|default %}
+                <img src="{{ content.headerImage.thumbnails['x400'] }}" class="img-fluid" alt="{{content.headerImage.title}}"/>
+            {% endif %}
             <h1 class="jumbotron-heading">{{ content.title }}</h1>
             <p class="lead text-muted">{{ content.article|raw }}</p>
         </div>


### PR DESCRIPTION
Add a header image to the homepage
==================================

Goal
----

Our homepage looks quite naked right now. To stir our users emotions, we would like to add a nice header image on 
the homepage.

Steps
-----

* Add a new property `headerImage` with the type `single_media_selection` to the
 `config/templates/pages/homepage.xml` file
* Log into the admin UI with user "admin" and password "admin"
* Switch to "Assets" and create a new asset collection with the name "Header Images"
* Upload a beautiful image to the newly created collection
* Modify the "Homepage", select your uploaded image as header image and save the page
* Add a new image format with the key `x400` to the `config/image-formats.xml` file
* Output the image in your `templates/pages/homepage.html.twig` in the right dimension

Hints
-----

* Use `{{ dump(content) }}` in the Twig template to find out how to output the header image URL.

More Information
----------------

To solve this assignment we need to understand a few different concepts in Sulu:

Each page in Sulu has a **template**. The template consists of two parts:

* an XML file with the structure of the page
* an HTML (Twig) file with the HTML of the page

A template is made up of **properties**. Each property has a name (for example "title") and a (content) type (for 
example `text_line`). The supported content types can be found in the documentation: 
http://docs.sulu.io/en/latest/reference/content-types/index.html

Furthermore, Sulu uses image formats to transparently create thumbnails in the respective sizes for uploaded images. 
A thumbnail is generated when it is accessed for the first time. That means that only thumbnails that are really used 
are stored on your disk.

When defining image formats, you can apply different actions to your source images. The most used action is scale, 
which resizes an image into the desired dimensions while keeping its original aspect ratio 
(http://docs.sulu.io/en/latest/book/image-formats.html).

Links
-----

* Next assignment pull request: [02 - Add a content block to the homepage](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/7)
* Source file of this assignment: [assignments/01.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/01.md)