### PR TITLE
03 - Add a footer navigation to the website

### DIFF
--- a/config/webspaces/example.xml
+++ b/config/webspaces/example.xml
@@ -31,6 +31,12 @@
                     <title lang="de">Hauptnavigation</title>
                 </meta>
             </context>
+            <context key="footer">
+                <meta>
+                    <title lang="en">Footer Navigation</title>
+                    <title lang="de">Footernavigation</title>
+                </meta>
+            </context>
         </contexts>
     </navigation>
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -57,7 +57,13 @@
     <footer class="footer mt-auto py-3">
         {% block footer %}
             <div class="container">
-                <span class="text-muted">Copyright {{ 'now'|date('Y') }} SULU</span>
+                {% for item in sulu_navigation_root_flat('footer') %}
+                    <a href="{{ sulu_content_path(item.url) }}">{{ item.title }}</a>
+
+                    {% if not loop.last %}&nbsp;|&nbsp;{% endif %}
+                {% endfor %}
+
+                <span class="text-muted float-right">Copyright {{ 'now'|date('Y') }} SULU</span>
             </div>
         {% endblock %}
     </footer>


### PR DESCRIPTION
Add a footer navigation to the website
======================================

Goal
----

Right now, our website displays a static footer section on every page. We want to provide a way to manually manage 
the links displayed in our footer section to our content manager.

Steps
-----

* Add a new navigation-context `footer` to the `config/webspaces/example.xml` file
* Log into the admin UI with user "admin" and password "admin"
* Create a new page and add the page to the footer navigation via the settings tab
* Output the new `footer` navigation in your `templates/base.html.twig`

Hints
-----

* Have a look at the existing `main` navigation-context

More Information
----------------

Sulu allows to define multiple so called navigation contexts to which the content manager can add an arbitrary number 
of pages. Navigation contexts are defined in the navigation-section of the webspace configuration and can be assigned 
to a page via the settings tab in the administration interface. 

After defining a navigation context, a developer can retrieve the navigation for a given context by using Twig 
extensions delivered with Sulu. The provided Twig extensions allow to retrieve a flat list of pages or a complete 
nested navigation tree.

Links
-----

* Next assignment pull request: [04 - Add additional languages to the website](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/9)
* Source file of this assignment: [assignments/03.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/03.md)