### PR TITLE
04 - Add additional languages to the website

### DIFF
--- a/config/webspaces/example.xml
+++ b/config/webspaces/example.xml
@@ -10,6 +10,8 @@
     <localizations>
         <!-- See: http://docs.sulu.io/en/latest/book/localization.html how to add new localizations -->
         <localization language="en" default="true"/>
+        <localization language="de"/>
+        <localization language="fr"/>
     </localizations>
 
     <default-templates>
@@ -48,22 +50,22 @@
             <environments>
                 <environment type="prod">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="stage">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="test">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="dev">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
             </environments>

--- a/src/Controller/Website/EventWebsiteController.php
+++ b/src/Controller/Website/EventWebsiteController.php
@@ -21,7 +21,7 @@ class EventWebsiteController extends AbstractController
     ) {
     }
 
-    #[Route('/event/{id}', name: 'app.event')]
+    #[Route('/{_locale}/event/{id}', name: 'app.event')]
     public function indexAction(int $id, Request $request): Response
     {
         $event = $this->eventRepository->findById($id, $request->getLocale());

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -41,6 +41,12 @@
                             </li>
                         {% endfor %}
                     </ul>
+
+                    <div class="navbar-nav">
+                        {% for localization in localizations %}
+                            <a class="nav-link" href="{{ localization.url }}">{{ localization.locale }}</a>
+                        {% endfor %}
+                    </div>
                 </div>
             </nav>
         </div>

--- a/tests/Functional/Controller/Website/EventWebsiteControllerTest.php
+++ b/tests/Functional/Controller/Website/EventWebsiteControllerTest.php
@@ -26,7 +26,7 @@ class EventWebsiteControllerTest extends SuluTestCase
     {
         $event = $this->createEvent('Sulu is awesome', 'en');
 
-        $crawler = $this->client->request('GET', '/event/' . $event->getId());
+        $crawler = $this->client->request('GET', '/en/event/' . $event->getId());
 
         $response = $this->client->getResponse();
         $this->assertInstanceOf(Response::class, $response);

--- a/tests/Functional/Pages/HomepageTest.php
+++ b/tests/Functional/Pages/HomepageTest.php
@@ -47,7 +47,7 @@ class HomepageTest extends SuluTestCase
             ],
         );
 
-        $crawler = $this->client->request(Request::METHOD_GET, '/homepage');
+        $crawler = $this->client->request(Request::METHOD_GET, '/en/homepage');
 
         $response = $this->client->getResponse();
         $this->assertInstanceOf(Response::class, $response);


### PR DESCRIPTION
Add additional languages to the website
=======================================

Goal
----

Our website is gaining traction in germany and france. To communicate with our new users in their native language we 
want to add german an french as additional languages and translate our existing content.

Steps
-----

* Add the new languages to the `config/webspaces/example.xml` file
* Run `bin/console sulu:document:initialize` to initialize the new languages
* Change the url configuration in the same file
* Log into the admin UI with user "admin" and password "admin"
* Give the admin user permissions for the new languages (Contacts -> Edit Adam Ministrator -> Permissions -> Roles -> Add new languages).
* Add content in the new languages
* Implement a language switcher in your `templates/base.html.twig`

Hints
-----

* Use `{{ dump(urls) }}` in the Twig template to find out how Sulu provides urls for multiple languages

More Information
----------------

As Sulu is built for internationally focused companies, managing localized content is a core feature of the system. 
Sulu does not only handle different languages, but also allows to manage different variations of a single language 
among different countries. 

Available localizations for the content of the website are defined in the webspace configuration file. 

Links
-----

* Next assignment pull request: [05 - Add a page template Event overview to the website](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/10)
* Source file of this assignment: [assignments/04.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/04.md)