### PR TITLE
05 - Add a page template Event overview to the website

### DIFF
--- a/config/templates/pages/event_overview.xml
+++ b/config/templates/pages/event_overview.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>event_overview</key>
+
+    <view>pages/event_overview</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>86400</cacheLifetime>
+
+    <meta>
+        <title lang="en">Event Overview</title>
+        <title lang="de">Veranstaltungsübersicht</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_editor">
+            <meta>
+                <title lang="en">Article</title>
+                <title lang="de">Artikel</title>
+            </meta>
+        </property>
+
+        <property name="events" type="smart_content">
+            <meta>
+                <title lang="en">Events</title>
+                <title lang="de">Veranstaltungen</title>
+            </meta>
+
+            <params>
+                <param name="provider" value="events"/>
+            </params>
+        </property>
+    </properties>
+</template>

--- a/templates/pages/event_overview.html.twig
+++ b/templates/pages/event_overview.html.twig
@@ -1,0 +1,26 @@
+{% extends "base.html.twig" %}
+
+{% block content %}
+    <section class="jumbotron text-center">
+        <div class="container">
+            <h1 class="jumbotron-heading">{{ content.title }}</h1>
+            <p class="lead text-muted">{{ content.article|raw }}</p>
+        </div>
+    </section>
+
+    <div class="container marketing">
+        <div class="row">
+            {% for event in content.events %}
+                <div class="col-lg-4 text-center">
+                    <h2 class="event-title">{{ event.resource.title }}</h2>
+                    <p>{{ event.resource.teaser }}</p>
+                    <p>
+                        <a class="btn btn-secondary" href="{{ path('app.event', {id: event.id}) }}" role="button">
+                            View details »
+                        </a>
+                    </p>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Functional/Pages/EventOverviewTest.php
+++ b/tests/Functional/Pages/EventOverviewTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Pages;
+
+use App\Tests\Functional\Traits\EventTrait;
+use App\Tests\Functional\Traits\PageTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EventOverviewTest extends SuluTestCase
+{
+    use EventTrait;
+    use PageTrait;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createWebsiteClient();
+        $this->initPhpcr();
+    }
+
+    public function testEventOverview(): void
+    {
+        $event1 = $this->createEvent('Sulu is awesome', 'en');
+        $this->enableEvent($event1);
+        $event2 = $this->createEvent('Symfony Live is awesome', 'en');
+        $this->enableEvent($event2);
+        $event3 = $this->createEvent('Disabled', 'en');
+
+        $this->createPage(
+            'event_overview',
+            'example',
+            [
+                'title' => 'Symfony Live',
+                'url' => '/events',
+                'published' => true,
+            ],
+        );
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/en/events');
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Symfony Live', $crawler->filter('h1')->html());
+        $this->assertNotNull($content = $crawler->filter('.event-title')->eq(0)->html());
+        $this->assertStringContainsString($event1->getTitle() ?: '', $content);
+        $this->assertNotNull($content = $crawler->filter('.event-title')->eq(1)->html());
+        $this->assertStringContainsString($event2->getTitle() ?: '', $content);
+    }
+
+    protected static function getDocumentManager(): DocumentManagerInterface
+    {
+        return static::getContainer()->get('sulu_document_manager.document_manager');
+    }
+}


### PR DESCRIPTION
Add an `event_overview` page template to the project
====================================================

Goal
----

Unfortunately our website is lacking an overview of all events. We would love to provide a page that displays all 
the events we are managing.

Steps
-----

* Create a new template by adding a `config/templates/pages/event_overview.xml` file and a
 `templates/pages/event_overview.html.twig` file
* Add a property `events` with type `smart_content` and the provider `events` to your `event_overview.xml`
* Log into the admin UI with user "admin" and password "admin"
* Create a new page `Events` and select the newly created `event_overview` template
* Assign the page to the `main` navigation context
* Output the events provided by the `smart_content` property in your `templates/pages/event_overview.html.twig`

Hints
-----

* Use `{{ dump(content.events) }}` in the Twig template to find out how the data that is returned by a
 `smart_content` property is structured.

More Information
----------------

The smart content is one of the most powerful content types of Sulu. It allows the content manager to dynamically 
configure an aggregation of content from different data sources. This is possible by registering data providers for 
different data sources in the system. A data provider defines which options are supported for its data source and is 
responsible for loading the respective data. 

Sulu already includes preconfigured data providers for pages from the content management section, contacts, accounts 
and media entities.

Links
-----

* Next assignment pull request: [06 - Add an event registration to the website](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/11)
* Source file of this assignment: [assignments/05.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/05.md)