### PR TITLE
06 - Add an event registration to the website

### DIFF
--- a/src/Controller/Website/EventWebsiteController.php
+++ b/src/Controller/Website/EventWebsiteController.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace App\Controller\Website;
 
 use App\Entity\Event;
+use App\Form\EventRegistrationType;
+use App\Repository\EventRegistrationRepository;
 use App\Repository\EventRepository;
 use Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -18,6 +21,7 @@ class EventWebsiteController extends AbstractController
     public function __construct(
         private readonly EventRepository $eventRepository,
         private readonly TemplateAttributeResolverInterface $templateAttributeResolver,
+        private readonly EventRegistrationRepository $eventRegistrationRepository,
     ) {
     }
 
@@ -29,11 +33,37 @@ class EventWebsiteController extends AbstractController
             throw new NotFoundHttpException();
         }
 
+        $registration = $this->eventRegistrationRepository->create($event);
+        $form = $this->createForm(EventRegistrationType::class, $registration);
+        $form->add(
+            'submit',
+            SubmitType::class,
+            [
+                'label' => 'Create',
+            ],
+        );
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->eventRegistrationRepository->save($registration);
+
+            return $this->redirectToRoute(
+                'app.event',
+                [
+                    'id' => $event->getId(),
+                    'success' => true,
+                ],
+            );
+        }
+
         return $this->render(
             'events/index.html.twig',
             $this->templateAttributeResolver->resolve(
                 [
                     'event' => $event,
+                    'success' => $request->query->get('success'),
+                    'form' => $form->createView(),
                     'content' => ['title' => $event->getTitle()],
                 ],
             ),

--- a/src/Entity/EventRegistration.php
+++ b/src/Entity/EventRegistration.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\EventRegistrationRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: EventRegistrationRepository::class)]
+class EventRegistration
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    #[Assert\NotBlank]
+    private ?string $firstName = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    #[Assert\NotBlank]
+    private ?string $lastName = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    private ?string $email = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $message = null;
+
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: Event::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private Event $event,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEvent(): Event
+    {
+        return $this->event;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): self
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): self
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+}

--- a/src/Form/EventRegistrationType.php
+++ b/src/Form/EventRegistrationType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\EventRegistration;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EventRegistrationType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('firstName')
+            ->add('lastName')
+            ->add('email')
+            ->add('message');
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => EventRegistration::class,
+            ],
+        );
+    }
+}

--- a/src/Repository/EventRegistrationRepository.php
+++ b/src/Repository/EventRegistrationRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Event;
+use App\Entity\EventRegistration;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<EventRegistration>
+ */
+class EventRegistrationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, EventRegistration::class);
+    }
+
+    public function create(Event $event): EventRegistration
+    {
+        return new EventRegistration($event);
+    }
+
+    public function save(EventRegistration $registration): void
+    {
+        $this->getEntityManager()->persist($registration);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/templates/events/index.html.twig
+++ b/templates/events/index.html.twig
@@ -1,5 +1,7 @@
 {% extends "base.html.twig" %}
 
+{% form_theme form 'bootstrap_4_layout.html.twig' %}
+
 {% block content %}
     <section class="jumbotron text-center">
         <div class="container">
@@ -10,6 +12,18 @@
 
     <div class="container">
         {{ event.description|raw }}
+    </div>
+
+    <div class="container">
+        {% if success %}
+            <div class="success">
+                <b>Thanks for your registration.</b>
+            </div>
+        {% else %}
+            <h2>Register for this event:</h2>
+
+            {{ form(form) }}
+        {% endif %}
     </div>
 
     {% if event.image %}

--- a/tests/Functional/Controller/Website/EventWebsiteControllerTest.php
+++ b/tests/Functional/Controller/Website/EventWebsiteControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional\Controller\Website;
 
+use App\Tests\Functional\Traits\EventRegistrationTrait;
 use App\Tests\Functional\Traits\EventTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -11,6 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EventWebsiteControllerTest extends SuluTestCase
 {
+    use EventRegistrationTrait;
     use EventTrait;
 
     private KernelBrowser $client;
@@ -33,5 +35,38 @@ class EventWebsiteControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
 
         $this->assertStringContainsString('Sulu is awesome', $crawler->filter('h1')->html());
+    }
+
+    public function testRegister(): void
+    {
+        $event = $this->createEvent('Sulu is awesome', 'en');
+
+        $crawler = $this->client->request('GET', '/en/event/' . $event->getId());
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertHttpStatusCode(200, $response);
+
+        $form = $crawler->filter('#event_registration_submit')->form(
+            [
+                'event_registration[firstName]' => 'Max',
+                'event_registration[lastName]' => 'Mustermann',
+                'event_registration[email]' => 'max@mustermann.at',
+                'event_registration[message]' => 'I would love to see this.',
+            ],
+        );
+
+        $this->client->submit($form);
+        $crawler = $this->client->followRedirect();
+
+        $this->assertStringContainsString('Thanks for your registration', $crawler->filter('.success')->html());
+
+        $registrations = $this->findEventRegistrations($event);
+
+        $this->assertCount(1, $registrations);
+        $this->assertSame('Max', $registrations[0]->getFirstName());
+        $this->assertSame('Mustermann', $registrations[0]->getLastName());
+        $this->assertSame('max@mustermann.at', $registrations[0]->getEmail());
+        $this->assertSame('I would love to see this.', $registrations[0]->getMessage());
     }
 }

--- a/tests/Functional/Traits/EventRegistrationTrait.php
+++ b/tests/Functional/Traits/EventRegistrationTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Traits;
+
+use App\Entity\Event;
+use App\Entity\EventRegistration;
+use App\Repository\EventRegistrationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+trait EventRegistrationTrait
+{
+    /**
+     * @return EventRegistration[]
+     */
+    public function findEventRegistrations(Event $event): array
+    {
+        return $this->getEventRegistrationRepository()->findBy(['event' => $event]);
+    }
+
+    protected function getEventRegistrationRepository(): EventRegistrationRepository
+    {
+        return static::getEntityManager()->getRepository(EventRegistration::class);
+    }
+
+    abstract protected static function getEntityManager(): EntityManagerInterface;
+}

--- a/tests/Unit/Entity/EventRegistrationTest.php
+++ b/tests/Unit/Entity/EventRegistrationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Event;
+use App\Entity\EventRegistration;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class EventRegistrationTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<Event>
+     */
+    private ObjectProphecy $event;
+
+    private EventRegistration $eventRegistration;
+
+    protected function setUp(): void
+    {
+        $this->event = $this->prophesize(Event::class);
+        $this->eventRegistration = new EventRegistration($this->event->reveal());
+    }
+
+    public function testFirstName(): void
+    {
+        $this->assertSame($this->eventRegistration, $this->eventRegistration->setFirstName('Max'));
+        $this->assertSame('Max', $this->eventRegistration->getFirstName());
+    }
+
+    public function testGetLastName(): void
+    {
+        $this->assertSame($this->eventRegistration, $this->eventRegistration->setLastName('Mustermann'));
+        $this->assertSame('Mustermann', $this->eventRegistration->getLastName());
+    }
+
+    public function testGetEmail(): void
+    {
+        $this->assertSame($this->eventRegistration, $this->eventRegistration->setEmail('max@mustermann.at'));
+        $this->assertSame('max@mustermann.at', $this->eventRegistration->getEmail());
+    }
+
+    public function testGetMessage(): void
+    {
+        $this->assertSame($this->eventRegistration, $this->eventRegistration->setMessage('I would live to see this.'));
+        $this->assertSame('I would live to see this.', $this->eventRegistration->getMessage());
+    }
+}


### PR DESCRIPTION
Allow for event registration on the website
===========================================

Goal
----

We want to allow our users to register themselves for our events in the future. Therefore we need to display a 
register form that includes input fields for a email address, a first and last name on each event detail page.

Steps
-----

* Follow the symfony best practices to add a new `EventRegistration` entity
* Add a many-to-one association between the `Event` entity and your newly created `EventRegistration` entity
* Don't forget to update your database schema with `bin/adminconsole doctrine:schema:update --force`
* Follow the symfony best practices to add a new `EventRegistration` form type
* Persist submitted registrations in your `src/Controller/Website/EventWebsiteController.php`
* Output your form and a success message in your `templates/events/index.html.twig`
* Browse one of your events and register yourself

Hints
-----

* Use `bin/adminconsole make:entity EventRegistration`
* https://symfony.com/doc/current/doctrine.html#creating-an-entity-class
* Use `bin/adminconsole make:form EventRegistrationType EventRegistration` 
* https://symfony.com/doc/current/best_practices/forms.html
* Run `bin/adminconsole doctrine:schema:validate`

More Information
----------------

This assignment is purely based on Symfony. No Sulu knowledge required ;-)

Links
-----

* Next assignment pull request: [07 - Display the registrations for each event in the admin interface](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/12)
* Source file of this assignment: [assignments/06.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/06.md)