### PR TITLE
08 - Add a custom entity Location

### DIFF
--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\LocationRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LocationRepository::class)]
+class Location
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $name = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $street = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $number = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $postalCode = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $city = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $countryCode = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(string $street): self
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    public function getNumber(): ?string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(string $number): self
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    public function setPostalCode(string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getCountryCode(): ?string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(string $countryCode): self
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+}

--- a/src/Repository/LocationRepository.php
+++ b/src/Repository/LocationRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Location;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Location>
+ */
+class LocationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Location::class);
+    }
+
+    public function create(): Location
+    {
+        $location = new Location();
+
+        $this->getEntityManager()->persist($location);
+
+        return $location;
+    }
+}

--- a/tests/Unit/Entity/LocationTest.php
+++ b/tests/Unit/Entity/LocationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Location;
+use PHPUnit\Framework\TestCase;
+
+class LocationTest extends TestCase
+{
+    private Location $location;
+
+    protected function setUp(): void
+    {
+        $this->location = new Location();
+    }
+
+    public function testName(): void
+    {
+        $this->assertNull($this->location->getName());
+        $this->assertSame($this->location, $this->location->setName('Sulu GmbH'));
+        $this->assertNotNull($this->location->getName());
+        $this->assertSame('Sulu GmbH', $this->location->getName());
+    }
+
+    public function testStreet(): void
+    {
+        $this->assertNull($this->location->getStreet());
+        $this->assertSame($this->location, $this->location->setStreet('Teststreet'));
+        $this->assertNotNull($this->location->getStreet());
+        $this->assertSame('Teststreet', $this->location->getStreet());
+    }
+
+    public function testNumber(): void
+    {
+        $this->assertNull($this->location->getNumber());
+        $this->assertSame($this->location, $this->location->setNumber('42'));
+        $this->assertNotNull($this->location->getNumber());
+        $this->assertSame('42', $this->location->getNumber());
+    }
+
+    public function testPostalCode(): void
+    {
+        $this->assertNull($this->location->getPostalCode());
+        $this->assertSame($this->location, $this->location->setPostalCode('6850'));
+        $this->assertNotNull($this->location->getPostalCode());
+        $this->assertSame('6850', $this->location->getPostalCode());
+    }
+
+    public function testCity(): void
+    {
+        $this->assertNull($this->location->getCity());
+        $this->assertSame($this->location, $this->location->setCity('Dornbirn'));
+        $this->assertNotNull($this->location->getCity());
+        $this->assertSame('Dornbirn', $this->location->getCity());
+    }
+
+    public function testCountryCode(): void
+    {
+        $this->assertNull($this->location->getCountryCode());
+        $this->assertSame($this->location, $this->location->setCountryCode('AT'));
+        $this->assertNotNull($this->location->getCountryCode());
+        $this->assertSame('AT', $this->location->getCountryCode());
+    }
+}


### PR DESCRIPTION
Add a custom entity `Location`
==============================

Goal
----

We are managing more and more events that take place at the same location. Because our content managers do not want 
to enter the same location information over and over again we would like to provide a central place for managing the 
locations of our events.

As this task is quite complex, we are going to break down the requirements into smaller pieces and multiple 
assignments. In this assignment, we want to add a new `Location` entity to our database model.

Steps
-----

* Follow the symfony best practices to add a `Location` entity with the following properties:
  * `name`
  * `street`
  * `city`
  * `countryCode`
* Don't forget to run `bin/adminconsole doctrine:schema:update --force`

Hints
-----

* Use `bin/adminconsole make:entity Location`
* https://symfony.com/doc/current/doctrine.html#creating-an-entity-class
* Run `bin/adminconsole doctrine:schema:validate`

More Information
----------------

This assignment is purely based on Symfony. No Sulu knowledge required ;-)

Links
-----

* Next assignment pull request: [09 - Add a list representation for locations in the admin interface](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/14)
* Source file of this assignment: [assignments/08.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/08.md)