### PR TITLE
09 - Add a list representation for locations in the admin interface

### DIFF
--- a/config/lists/locations.xml
+++ b/config/lists/locations.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<list xmlns="http://schemas.sulu.io/list-builder/list">
+    <key>locations</key>
+
+    <properties>
+        <property name="id" visibility="no" translation="sulu_admin.id">
+            <field-name>id</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="name" visibility="always" searchability="yes" translation="sulu_admin.name">
+            <field-name>name</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="street" visibility="yes" searchability="yes" translation="sulu_contact.street">
+            <field-name>street</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="number" visibility="yes" searchability="yes" translation="sulu_contact.number">
+            <field-name>number</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="postalCode" visibility="yes" searchability="yes" translation="sulu_contact.zip">
+            <field-name>postalCode</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="city" visibility="yes" searchability="yes" translation="sulu_contact.city">
+            <field-name>city</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+
+        <property name="countryCode" visibility="yes" searchability="yes" translation="sulu_contact.country">
+            <field-name>countryCode</field-name>
+            <entity-name>App\Entity\Location</entity-name>
+        </property>
+    </properties>
+</list>

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -18,6 +18,10 @@ sulu_admin:
             routes:
                 list: app.get_event_registration_list
 
+        locations:
+            routes:
+                list: app.get_location_list
+
     # Registering Selection Field Types in this section
     field_type_options:
         selection:

--- a/src/Admin/LocationAdmin.php
+++ b/src/Admin/LocationAdmin.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use App\Entity\Location;
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+
+class LocationAdmin extends Admin
+{
+    final public const LOCATION_LIST_KEY = 'locations';
+
+    final public const LOCATION_LIST_VIEW = 'app.locations_list';
+
+    public function __construct(
+        private readonly ViewBuilderFactoryInterface $viewBuilderFactory,
+    ) {
+    }
+
+    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
+    {
+        $module = $navigationItemCollection->get('app.events');
+
+        $locations = new NavigationItem('app.locations');
+        $locations->setPosition(10);
+        $locations->setView(static::LOCATION_LIST_VIEW);
+
+        $module->addChild($locations);
+    }
+
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        $listView = $this->viewBuilderFactory->createListViewBuilder(self::LOCATION_LIST_VIEW, '/locations')
+            ->setResourceKey(Location::RESOURCE_KEY)
+            ->setListKey(self::LOCATION_LIST_KEY)
+            ->setTitle('app.locations')
+            ->addListAdapters(['table'])
+            ->addToolbarActions([]);
+        $viewCollection->add($listView);
+    }
+}

--- a/src/Controller/Admin/LocationController.php
+++ b/src/Controller/Admin/LocationController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Common\DoctrineListRepresentationFactory;
+use App\Entity\Location;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LocationController extends AbstractController
+{
+    public function __construct(
+        private readonly DoctrineListRepresentationFactory $doctrineListRepresentationFactory,
+    ) {
+    }
+
+    #[Route(path: '/admin/api/locations', methods: ['GET'], name: 'app.get_location_list')]
+    public function getListAction(): Response
+    {
+        $listRepresentation = $this->doctrineListRepresentationFactory->createDoctrineListRepresentation(
+            Location::RESOURCE_KEY,
+        );
+
+        return $this->json($listRepresentation->toArray());
+    }
+}

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -11,6 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: LocationRepository::class)]
 class Location
 {
+    final public const RESOURCE_KEY = 'locations';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]

--- a/tests/Functional/Controller/Admin/LocationControllerTest.php
+++ b/tests/Functional/Controller/Admin/LocationControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Admin;
+
+use App\Tests\Functional\Traits\LocationTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationControllerTest extends SuluTestCase
+{
+    use LocationTrait;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient();
+        $this->purgeDatabase();
+    }
+
+    public function testGetList(): void
+    {
+        $location1 = $this->createLocation('Sulu');
+        $location2 = $this->createLocation('Symfony');
+
+        $this->client->jsonRequest('GET', '/admin/api/locations');
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /**
+         * @var array{
+         *     _embedded: array{
+         *         locations: array<array{
+         *             id: int,
+         *             name: string,
+         *         }>
+         *     },
+         *     total: int,
+         * } $result
+         */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertSame(2, $result['total']);
+        $this->assertCount(2, $result['_embedded']['locations']);
+        $items = $result['_embedded']['locations'];
+
+        $this->assertSame($location1->getId(), $items[0]['id']);
+        $this->assertSame($location2->getId(), $items[1]['id']);
+
+        $this->assertSame($location1->getName(), $items[0]['name']);
+        $this->assertSame($location2->getName(), $items[1]['name']);
+    }
+}

--- a/tests/Functional/Traits/LocationTrait.php
+++ b/tests/Functional/Traits/LocationTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Traits;
+
+use App\Entity\Location;
+use App\Repository\LocationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+trait LocationTrait
+{
+    public function createLocation(string $name): Location
+    {
+        $location = $this->getLocationRepository()->create();
+        $location->setName($name);
+        $location->setStreet('');
+        $location->setNumber('');
+        $location->setPostalCode('');
+        $location->setCity('');
+        $location->setCountryCode('');
+
+        static::getEntityManager()->persist($location);
+        static::getEntityManager()->flush();
+
+        return $location;
+    }
+
+    protected function getLocationRepository(): LocationRepository
+    {
+        return static::getEntityManager()->getRepository(Location::class);
+    }
+
+    abstract protected static function getEntityManager(): EntityManagerInterface;
+}

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -7,5 +7,6 @@
     "app.end_date": "Ende",
     "app.enable_event": "Veranstaltungen aktivieren",
     "app.enabled": "Aktiviert",
-    "app.location": "Standort"
+    "app.location": "Standort",
+    "app.locations": "Standorte"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -7,5 +7,6 @@
     "app.end_date": "Ende",
     "app.enable_event": "Enable event",
     "app.enabled": "Enabled",
-    "app.location": "Location"
+    "app.location": "Location",
+    "app.locations": "Locations"
 }


### PR DESCRIPTION
Display location list in the admin interface
============================================

Goal
----

After adding the `Location` entity in the last assignment, we want to add a new navigation item to the Sulu 
administration interface that allows to access a list of all managed locations.

Steps
-----

* Create a new admin API-Controller `App\Controller\Admin\LocationController` with a `getListAction` to that returns 
 our locations
* Register the controller in your `config/routes_admin.yaml`
* Configure a new resource `locations` in your `config/packages/sulu_admin.yaml`
* Add a new list configuration for `locations` in a `config/lists/locations.xml` file
* Create a new Admin class `src/Admin/LocationAdmin.php`
* Configure a new admin navigation item in your `src/Admin/LocationAdmin.php`
* Use the `ListRouteBuilder` to add a new admin route in your `src/Admin/LocationAdmin.php`
* Log into the admin UI with user "admin" and password "admin"
* Goto the list of locations and see an empty list :)

Hints
-----

* Have a look at the existing event navigation item in the `src/Admin/EventAdmin.php` file

More Information
----------------

Have a look at assignment 07 for more information.

Links
-----

* Next assignment pull request: [10 - Add a form to add, edit or delete locations in the admin interface](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/15)
* Source file of this assignment: [assignments/09.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/09.md)