### PR TITLE
10 - Add a form to add, edit or delete locations in the admin interface

### DIFF
--- a/config/forms/location_details.xml
+++ b/config/forms/location_details.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>location_details</key>
+
+    <properties>
+        <property name="name" type="text_line" mandatory="true">
+            <meta>
+                <title>sulu_admin.name</title>
+            </meta>
+        </property>
+
+        <property name="street" type="text_line" colspan="9">
+            <meta>
+                <title>sulu_contact.street</title>
+            </meta>
+        </property>
+
+        <property name="number" type="text_line" colspan="3">
+            <meta>
+                <title>sulu_contact.number</title>
+            </meta>
+        </property>
+
+        <property name="postalCode" type="text_line" colspan="3">
+            <meta>
+                <title>sulu_contact.zip</title>
+            </meta>
+        </property>
+
+        <property name="city" type="text_line" colspan="6">
+            <meta>
+                <title>sulu_contact.city</title>
+            </meta>
+        </property>
+
+        <property name="countryCode" type="single_select" colspan="3">
+            <meta>
+                <title>sulu_contact.country</title>
+            </meta>
+
+            <params>
+                <param
+                        name="values"
+                        type="expression"
+                        value="service('App\\Service\\CountryCodeSelect').getValues()"
+                />
+            </params>
+        </property>
+    </properties>
+</form>

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -21,6 +21,7 @@ sulu_admin:
         locations:
             routes:
                 list: app.get_location_list
+                detail: app.get_location
 
     # Registering Selection Field Types in this section
     field_type_options:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,3 +36,6 @@ services:
         tags: [{name: 'sulu.smart_content.data_provider', alias: 'events'}]
         bind:
             $repository: '@App\Repository\EventRepository'
+
+    App\Service\CountryCodeSelect:
+        public: true

--- a/src/Admin/LocationAdmin.php
+++ b/src/Admin/LocationAdmin.php
@@ -8,6 +8,7 @@ use App\Entity\Location;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 
@@ -16,6 +17,10 @@ class LocationAdmin extends Admin
     final public const LOCATION_LIST_KEY = 'locations';
 
     final public const LOCATION_LIST_VIEW = 'app.locations_list';
+
+    final public const LOCATION_ADD_FORM_VIEW = 'app.location_add_form';
+
+    final public const LOCATION_EDIT_FORM_VIEW = 'app.location_edit_form';
 
     public function __construct(
         private readonly ViewBuilderFactoryInterface $viewBuilderFactory,
@@ -35,12 +40,50 @@ class LocationAdmin extends Admin
 
     public function configureViews(ViewCollection $viewCollection): void
     {
+        $listToolbarActions = [
+            new ToolbarAction('sulu_admin.add'),
+            new ToolbarAction('sulu_admin.delete'),
+        ];
         $listView = $this->viewBuilderFactory->createListViewBuilder(self::LOCATION_LIST_VIEW, '/locations')
             ->setResourceKey(Location::RESOURCE_KEY)
             ->setListKey(self::LOCATION_LIST_KEY)
             ->setTitle('app.locations')
             ->addListAdapters(['table'])
-            ->addToolbarActions([]);
+            ->setAddView(static::LOCATION_ADD_FORM_VIEW)
+            ->setEditView(static::LOCATION_EDIT_FORM_VIEW)
+            ->addToolbarActions($listToolbarActions);
         $viewCollection->add($listView);
+
+        $addFormView = $this->viewBuilderFactory->createResourceTabViewBuilder(self::LOCATION_ADD_FORM_VIEW, '/locations/add')
+            ->setResourceKey('locations')
+            ->setBackView(static::LOCATION_LIST_VIEW);
+        $viewCollection->add($addFormView);
+
+        $addDetailsFormView = $this->viewBuilderFactory->createFormViewBuilder(self::LOCATION_ADD_FORM_VIEW . '.details', '/details')
+            ->setResourceKey('locations')
+            ->setFormKey('location_details')
+            ->setTabTitle('sulu_admin.details')
+            ->setEditView(static::LOCATION_EDIT_FORM_VIEW)
+            ->addToolbarActions([new ToolbarAction('sulu_admin.save')])
+            ->setParent(static::LOCATION_ADD_FORM_VIEW);
+        $viewCollection->add($addDetailsFormView);
+
+        $editFormView = $this->viewBuilderFactory->createResourceTabViewBuilder(static::LOCATION_EDIT_FORM_VIEW, '/locations/:id')
+            ->setResourceKey('locations')
+            ->setBackView(static::LOCATION_LIST_VIEW)
+            ->setTitleProperty('title');
+        $viewCollection->add($editFormView);
+
+        $formToolbarActions = [
+            new ToolbarAction('sulu_admin.save'),
+            new ToolbarAction('sulu_admin.delete'),
+        ];
+        $editDetailsFormView = $this->viewBuilderFactory->createFormViewBuilder(static::LOCATION_EDIT_FORM_VIEW . '.details', '/details')
+            ->setResourceKey('locations')
+            ->setFormKey('location_details')
+            ->setTabTitle('sulu_admin.details')
+            ->addToolbarActions($formToolbarActions)
+            ->setParent(static::LOCATION_EDIT_FORM_VIEW);
+        $viewCollection->add($editDetailsFormView);
     }
 }

--- a/src/Controller/Admin/LocationController.php
+++ b/src/Controller/Admin/LocationController.php
@@ -6,15 +6,78 @@ namespace App\Controller\Admin;
 
 use App\Common\DoctrineListRepresentationFactory;
 use App\Entity\Location;
+use App\Repository\LocationRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @phpstan-type LocationData array{
+ *     id: int|null,
+ *     name: string,
+ *     street: string|null,
+ *     number: string|null,
+ *     postalCode: string|null,
+ *     city: string|null,
+ *     countryCode: string|null,
+ * }
+ */
 class LocationController extends AbstractController
 {
     public function __construct(
+        private readonly LocationRepository $locationRepository,
         private readonly DoctrineListRepresentationFactory $doctrineListRepresentationFactory,
     ) {
+    }
+
+    #[Route(path: '/admin/api/locations/{id}', methods: ['GET'], name: 'app.get_location')]
+    public function getAction(int $id): Response
+    {
+        $location = $this->load($id);
+        if (!$location instanceof Location) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->json($this->getDataForEntity($location));
+    }
+
+    #[Route(path: '/admin/api/locations/{id}', methods: ['PUT'], name: 'app.put_location')]
+    public function putAction(int $id, Request $request): Response
+    {
+        $location = $this->load($id);
+        if (!$location instanceof Location) {
+            throw new NotFoundHttpException();
+        }
+
+        /** @var LocationData $data */
+        $data = $request->toArray();
+        $this->mapDataToEntity($data, $location);
+        $this->save($location);
+
+        return $this->json($this->getDataForEntity($location));
+    }
+
+    #[Route(path: '/admin/api/locations', methods: ['POST'], name: 'app.post_location')]
+    public function postAction(Request $request): Response
+    {
+        $location = $this->create();
+
+        /** @var LocationData $data */
+        $data = $request->toArray();
+        $this->mapDataToEntity($data, $location);
+        $this->save($location);
+
+        return $this->json($this->getDataForEntity($location), 201);
+    }
+
+    #[Route(path: '/admin/api/locations/{id}', methods: ['DELETE'], name: 'app.delete_location')]
+    public function deleteAction(int $id): Response
+    {
+        $this->remove($id);
+
+        return $this->json(null, 204);
     }
 
     #[Route(path: '/admin/api/locations', methods: ['GET'], name: 'app.get_location_list')]
@@ -25,5 +88,54 @@ class LocationController extends AbstractController
         );
 
         return $this->json($listRepresentation->toArray());
+    }
+
+    /**
+     * @return LocationData
+     */
+    protected function getDataForEntity(Location $entity): array
+    {
+        return [
+            'id' => $entity->getId(),
+            'name' => $entity->getName() ?? '',
+            'street' => $entity->getStreet(),
+            'number' => $entity->getNumber(),
+            'postalCode' => $entity->getPostalCode(),
+            'city' => $entity->getCity(),
+            'countryCode' => $entity->getCountryCode(),
+        ];
+    }
+
+    /**
+     * @param LocationData $data
+     */
+    protected function mapDataToEntity(array $data, Location $entity): void
+    {
+        $entity->setName($data['name']);
+        $entity->setStreet($data['street'] ?? '');
+        $entity->setNumber($data['number'] ?? '');
+        $entity->setPostalCode($data['postalCode'] ?? '');
+        $entity->setCity($data['city'] ?? '');
+        $entity->setCountryCode($data['countryCode'] ?? '');
+    }
+
+    protected function load(int $id): ?Location
+    {
+        return $this->locationRepository->findById($id);
+    }
+
+    protected function create(): Location
+    {
+        return $this->locationRepository->create();
+    }
+
+    protected function save(Location $entity): void
+    {
+        $this->locationRepository->save($entity);
+    }
+
+    protected function remove(int $id): void
+    {
+        $this->locationRepository->remove($id);
     }
 }

--- a/src/Repository/LocationRepository.php
+++ b/src/Repository/LocationRepository.php
@@ -20,10 +20,29 @@ class LocationRepository extends ServiceEntityRepository
 
     public function create(): Location
     {
-        $location = new Location();
+        return new Location();
+    }
 
+    public function remove(int $id): void
+    {
+        /** @var object $location */
+        $location = $this->getEntityManager()->getReference(
+            $this->getClassName(),
+            $id,
+        );
+
+        $this->getEntityManager()->remove($location);
+        $this->getEntityManager()->flush();
+    }
+
+    public function save(Location $location): void
+    {
         $this->getEntityManager()->persist($location);
+        $this->getEntityManager()->flush();
+    }
 
-        return $location;
+    public function findById(int $id): ?Location
+    {
+        return $this->find($id);
     }
 }

--- a/src/Service/CountryCodeSelect.php
+++ b/src/Service/CountryCodeSelect.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Symfony\Component\Intl\Countries;
+
+class CountryCodeSelect
+{
+    /**
+     * @return mixed[]
+     */
+    public function getValues(): array
+    {
+        $values = [];
+
+        foreach (Countries::getNames() as $code => $title) {
+            $values[] = [
+                'name' => $code,
+                'title' => $title,
+            ];
+        }
+
+        return $values;
+    }
+}

--- a/tests/Functional/Controller/Admin/LocationControllerTest.php
+++ b/tests/Functional/Controller/Admin/LocationControllerTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional\Controller\Admin;
 
+use App\Controller\Admin\LocationController;
 use App\Tests\Functional\Traits\LocationTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @phpstan-import-type LocationData from LocationController
+ */
 class LocationControllerTest extends SuluTestCase
 {
     use LocationTrait;
@@ -53,5 +57,195 @@ class LocationControllerTest extends SuluTestCase
 
         $this->assertSame($location1->getName(), $items[0]['name']);
         $this->assertSame($location2->getName(), $items[1]['name']);
+    }
+
+    public function testGet(): void
+    {
+        $location = $this->createLocation('Sulu');
+
+        $this->client->jsonRequest('GET', '/admin/api/locations/' . $location->getId());
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /** @var LocationData $result */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertSame($location->getId(), $result['id']);
+        $this->assertSame($location->getName(), $result['name']);
+    }
+
+    public function testPost(): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/admin/api/locations',
+            [
+                'name' => 'Sulu',
+                'street' => 'Teststreet',
+                'number' => '42',
+                'postalCode' => '6850',
+                'city' => 'Dornbirn',
+                'countryCode' => 'AT',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /** @var LocationData $result */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(201, $response);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertNotNull($result['id']);
+        $this->assertSame('Sulu', $result['name']);
+        $this->assertSame('Teststreet', $result['street']);
+        $this->assertSame('42', $result['number']);
+        $this->assertSame('6850', $result['postalCode']);
+        $this->assertSame('Dornbirn', $result['city']);
+        $this->assertSame('AT', $result['countryCode']);
+
+        $result = $this->findLocationById($result['id']);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Sulu', $result->getName());
+        $this->assertSame('Teststreet', $result->getStreet());
+        $this->assertSame('42', $result->getNumber());
+        $this->assertSame('6850', $result->getPostalCode());
+        $this->assertSame('Dornbirn', $result->getCity());
+        $this->assertSame('AT', $result->getCountryCode());
+    }
+
+    public function testPostNullValues(): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/admin/api/locations',
+            [
+                'name' => 'Sulu',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /** @var LocationData $result */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(201, $response);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertNotNull($result['id']);
+        $this->assertSame('Sulu', $result['name']);
+        $this->assertEmpty($result['street']);
+        $this->assertEmpty($result['number']);
+        $this->assertEmpty($result['postalCode']);
+        $this->assertEmpty($result['city']);
+        $this->assertEmpty($result['countryCode']);
+
+        $result = $this->findLocationById($result['id']);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Sulu', $result->getName());
+        $this->assertEmpty($result->getStreet());
+        $this->assertEmpty($result->getNumber());
+        $this->assertEmpty($result->getPostalCode());
+        $this->assertEmpty($result->getCity());
+        $this->assertEmpty($result->getCountryCode());
+    }
+
+    public function testPut(): void
+    {
+        $location = $this->createLocation('Symfony');
+
+        $this->client->jsonRequest(
+            'PUT',
+            '/admin/api/locations/' . $location->getId(),
+            [
+                'name' => 'Sulu',
+                'street' => 'Teststreet',
+                'number' => '42',
+                'postalCode' => '6850',
+                'city' => 'Dornbirn',
+                'countryCode' => 'AT',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /** @var LocationData $result */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertNotNull($result['id']);
+        $this->assertSame('Sulu', $result['name']);
+        $this->assertSame('Teststreet', $result['street']);
+        $this->assertSame('42', $result['number']);
+        $this->assertSame('6850', $result['postalCode']);
+        $this->assertSame('Dornbirn', $result['city']);
+        $this->assertSame('AT', $result['countryCode']);
+
+        $result = $this->findLocationById($result['id']);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Sulu', $result->getName());
+        $this->assertSame('Teststreet', $result->getStreet());
+        $this->assertSame('42', $result->getNumber());
+        $this->assertSame('6850', $result->getPostalCode());
+        $this->assertSame('Dornbirn', $result->getCity());
+        $this->assertSame('AT', $result->getCountryCode());
+    }
+
+    public function testPutNullValues(): void
+    {
+        $location = $this->createLocation('Symfony');
+
+        $this->client->jsonRequest(
+            'PUT',
+            '/admin/api/locations/' . $location->getId(),
+            [
+                'name' => 'Sulu',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        /** @var LocationData $result */
+        $result = \json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertNotNull($result['id']);
+        $this->assertSame('Sulu', $result['name']);
+        $this->assertEmpty($result['street']);
+        $this->assertEmpty($result['number']);
+        $this->assertEmpty($result['postalCode']);
+        $this->assertEmpty($result['city']);
+        $this->assertEmpty($result['countryCode']);
+
+        $result = $this->findLocationById($result['id']);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Sulu', $result->getName());
+        $this->assertEmpty($result->getStreet());
+        $this->assertEmpty($result->getNumber());
+        $this->assertEmpty($result->getPostalCode());
+        $this->assertEmpty($result->getCity());
+        $this->assertEmpty($result->getCountryCode());
+    }
+
+    public function testDelete(): void
+    {
+        $location = $this->createLocation('Symfony');
+
+        /** @var int $locationId */
+        $locationId = $location->getId();
+
+        $this->client->jsonRequest('DELETE', '/admin/api/locations/' . $location->getId());
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertHttpStatusCode(204, $response);
+
+        $this->assertNull($this->findLocationById($locationId));
     }
 }

--- a/tests/Functional/Traits/LocationTrait.php
+++ b/tests/Functional/Traits/LocationTrait.php
@@ -26,6 +26,11 @@ trait LocationTrait
         return $location;
     }
 
+    public function findLocationById(int $id): ?Location
+    {
+        return $this->getLocationRepository()->findById($id);
+    }
+
     protected function getLocationRepository(): LocationRepository
     {
         return static::getEntityManager()->getRepository(Location::class);


### PR DESCRIPTION
Add a form to add, edit or delete locations in the admin interface
==================================================================

Goal
----

We have already added a list that display existing locations in the last assignment. To complete our location 
management functionality, we want to implement a form that allows to add, edit and delete locations via the Sulu 
administration interface.

Steps
-----

* Add the logic for adding, modifying and deleting locations to your `App\Controller\Admin\LocationController`
* Configure the detail route for the `locations` resource in your `config/packages/sulu_admin.yaml`
* Add a form-configuration for `location_details` in a `config/forms/location_details.xml` file
* Add admin routes for adding and editing locations in your `src\Admin\LocationAdmin`
* Log into the admin UI with user "admin" and password "admin"
* Navigate to the locations list and add a new location

Hints
-----

* Have a look at the admin API-Controller `App\Controller\Admin\EventController` for the Event entity
* Have a look at the existing admin-routes for the Event entity in `src/Admin/AppAdmin.php` file

More Information
----------------

Have a look at assignment 07 for more information.

Links
-----

* Next assignment pull request: [11 - Add a relation between events and locations](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/16)
* Source file of this assignment: [assignments/10.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/10.md)