### PR TITLE
11 - Add a relation between events and locations

### DIFF
--- a/config/forms/event_details.xml
+++ b/config/forms/event_details.xml
@@ -24,7 +24,7 @@
             </params>
         </property>
 
-        <property name="location" type="text_line" colspan="6">
+        <property name="locationId" type="single_location_selection" mandatory="true" colspan="6">
             <meta>
                 <title>app.location</title>
             </meta>

--- a/config/packages/sulu_admin.yaml
+++ b/config/packages/sulu_admin.yaml
@@ -38,3 +38,17 @@ sulu_admin:
                         icon: fa-calendar
                         label: 'app.events'
                         overlay_title: 'app.events'
+
+        single_selection:
+            single_location_selection:
+                default_type: list_overlay
+                resource_key: locations
+                types:
+                    list_overlay:
+                        adapter: table
+                        list_key: locations
+                        display_properties:
+                            - name
+                        icon: fa-home
+                        empty_text: 'app.location.no_selections'
+                        overlay_title: 'app.locations'

--- a/src/Controller/Admin/EventController.php
+++ b/src/Controller/Admin/EventController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Admin;
 use App\Common\DoctrineListRepresentationFactory;
 use App\Entity\Event;
 use App\Repository\EventRepository;
+use App\Repository\LocationRepository;
 use DateTimeImmutable;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -25,7 +26,7 @@ use Symfony\Component\Routing\Annotation\Route;
  *     description: string|null,
  *     startDate: string|null,
  *     endDate: string|null,
- *     location: string|null,
+ *     locationId: number|null,
  * }
  */
 class EventController extends AbstractController
@@ -34,6 +35,7 @@ class EventController extends AbstractController
         private readonly EventRepository $eventRepository,
         private readonly MediaRepositoryInterface $mediaRepository,
         private readonly DoctrineListRepresentationFactory $doctrineListRepresentationFactory,
+        private readonly LocationRepository $locationRepository,
     ) {
     }
 
@@ -127,6 +129,7 @@ class EventController extends AbstractController
         $image = $entity->getImage();
         $startDate = $entity->getStartDate();
         $endDate = $entity->getEndDate();
+        $location = $entity->getLocation();
 
         return [
             'id' => $entity->getId(),
@@ -139,7 +142,7 @@ class EventController extends AbstractController
             'description' => $entity->getDescription(),
             'startDate' => null !== $startDate ? $startDate->format('c') : null,
             'endDate' => null !== $endDate ? $endDate->format('c') : null,
-            'location' => $entity->getLocation(),
+            'locationId' => null !== $location ? $location->getId() : null,
         ];
     }
 
@@ -156,7 +159,7 @@ class EventController extends AbstractController
         $entity->setDescription($data['description'] ?? '');
         $entity->setStartDate($data['startDate'] ? new DateTimeImmutable($data['startDate']) : null);
         $entity->setEndDate($data['endDate'] ? new DateTimeImmutable($data['endDate']) : null);
-        $entity->setLocation($data['location'] ?? null);
+        $entity->setLocation($data['locationId'] ? $this->locationRepository->findById((int) $data['locationId']) : null);
     }
 
     protected function load(int $id, Request $request): ?Event

--- a/src/DataFixtures/ORM/AppFixtures.php
+++ b/src/DataFixtures/ORM/AppFixtures.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Event;
+use App\Entity\Location;
 use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -53,7 +54,8 @@ class AppFixtures extends Fixture implements OrderedFixtureInterface
      */
     private function loadEvents(ObjectManager $manager, array $images): void
     {
-        $repository = $manager->getRepository(Event::class);
+        $eventRepository = $manager->getRepository(Event::class);
+        $locationRepository = $manager->getRepository(Location::class);
 
         $data = [
             [
@@ -129,18 +131,30 @@ class AppFixtures extends Fixture implements OrderedFixtureInterface
         ];
 
         foreach ($data as $item) {
-            $event = $repository->create(self::LOCALE);
+            $location = null;
+            if ($item['location']) {
+                $location = $locationRepository->create();
+                $location->setName($item['location']);
+                $location->setStreet('');
+                $location->setNumber('');
+                $location->setCity('');
+                $location->setCountryCode('');
+                $location->setPostalCode('');
+                $locationRepository->save($location);
+            }
+
+            $event = $eventRepository->create(self::LOCALE);
 
             $event->setTitle($item['title']);
             $event->setImage($images[$item['image']] ?? null);
-            $event->setLocation($item['location']);
+            $event->setLocation($location);
             $event->setTeaser($item['teaser']);
             $event->setDescription('<p>' . $item['description'] . '</p>');
             $event->setStartDate(new DateTimeImmutable($item['startDate']));
             $event->setEndDate(new DateTimeImmutable($item['endDate']));
             $event->setEnabled($item['enabled']);
 
-            $repository->save($event);
+            $eventRepository->save($event);
         }
     }
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -31,8 +31,9 @@ class Event
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $endDate = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
-    private ?string $location = null;
+    #[ORM\ManyToOne(targetEntity: Location::class)]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    private ?Location $location = null;
 
     #[ORM\ManyToOne(targetEntity: MediaInterface::class)]
     #[ORM\JoinColumn(onDelete: 'SET NULL')]
@@ -92,12 +93,12 @@ class Event
         return $this;
     }
 
-    public function getLocation(): ?string
+    public function getLocation(): ?Location
     {
         return $this->location;
     }
 
-    public function setLocation(?string $location): self
+    public function setLocation(?Location $location): self
     {
         $this->location = $location;
 

--- a/tests/Functional/Controller/Admin/EventControllerTest.php
+++ b/tests/Functional/Controller/Admin/EventControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Functional\Controller\Admin;
 
 use App\Controller\Admin\EventController;
 use App\Tests\Functional\Traits\EventTrait;
+use App\Tests\Functional\Traits\LocationTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 class EventControllerTest extends SuluTestCase
 {
     use EventTrait;
+    use LocationTrait;
 
     private KernelBrowser $client;
 
@@ -77,6 +79,8 @@ class EventControllerTest extends SuluTestCase
 
     public function testPost(): void
     {
+        $location = $this->createLocation('Sulu HQ');
+
         $this->client->jsonRequest(
             'POST',
             '/admin/api/events?locale=de',
@@ -86,7 +90,7 @@ class EventControllerTest extends SuluTestCase
                 'startDate' => '2019-01-01 12:00',
                 'endDate' => '2019-01-02 12:00',
                 'description' => 'Sulu is really awesome',
-                'location' => 'Dornbirn',
+                'locationId' => $location->getId(),
             ],
         );
 
@@ -104,7 +108,7 @@ class EventControllerTest extends SuluTestCase
         $this->assertSame('2019-01-01T12:00:00+00:00', $result['startDate']);
         $this->assertSame('2019-01-02T12:00:00+00:00', $result['endDate']);
         $this->assertSame('Sulu is really awesome', $result['description']);
-        $this->assertSame('Dornbirn', $result['location']);
+        $this->assertSame($location->getId(), $result['locationId']);
 
         $result = $this->findEventById($result['id'], 'de');
 
@@ -117,7 +121,8 @@ class EventControllerTest extends SuluTestCase
         $this->assertNotNull($result->getEndDate());
         $this->assertSame('2019-01-02T12:00:00+00:00', $result->getEndDate()->format('c'));
         $this->assertSame('Sulu is really awesome', $result->getDescription());
-        $this->assertSame('Dornbirn', $result->getLocation());
+        $this->assertNotNull($result->getLocation());
+        $this->assertSame($location->getId(), $result->getLocation()->getId());
     }
 
     public function testPostNullValues(): void
@@ -131,7 +136,7 @@ class EventControllerTest extends SuluTestCase
                 'startDate' => null,
                 'endDate' => null,
                 'description' => null,
-                'location' => null,
+                'locationId' => null,
             ],
         );
 
@@ -149,7 +154,7 @@ class EventControllerTest extends SuluTestCase
         $this->assertNull($result['startDate']);
         $this->assertNull($result['endDate']);
         $this->assertSame($result['description'], '');
-        $this->assertNull($result['location']);
+        $this->assertNull($result['locationId']);
 
         $result = $this->findEventById($result['id'], 'de');
 
@@ -166,6 +171,7 @@ class EventControllerTest extends SuluTestCase
     public function testPut(): void
     {
         $event = $this->createEvent('Symfony', 'de');
+        $location = $this->createLocation('Sulu HQ');
 
         $this->client->jsonRequest(
             'PUT',
@@ -176,7 +182,7 @@ class EventControllerTest extends SuluTestCase
                 'startDate' => '2019-01-01 12:00',
                 'endDate' => '2019-01-02 12:00',
                 'description' => 'Symfony Live is really awesome',
-                'location' => 'Dornbirn',
+                'locationId' => $location->getId(),
             ],
         );
 
@@ -194,7 +200,7 @@ class EventControllerTest extends SuluTestCase
         $this->assertSame('2019-01-01T12:00:00+00:00', $result['startDate']);
         $this->assertSame('2019-01-02T12:00:00+00:00', $result['endDate']);
         $this->assertSame('Symfony Live is really awesome', $result['description']);
-        $this->assertSame('Dornbirn', $result['location']);
+        $this->assertSame($location->getId(), $result['locationId']);
 
         $result = $this->findEventById($result['id'], 'de');
 
@@ -207,7 +213,8 @@ class EventControllerTest extends SuluTestCase
         $this->assertNotNull($result->getEndDate());
         $this->assertSame('2019-01-02T12:00:00+00:00', $result->getEndDate()->format('c'));
         $this->assertSame('Symfony Live is really awesome', $result->getDescription());
-        $this->assertSame('Dornbirn', $result->getLocation());
+        $this->assertNotNull($result->getLocation());
+        $this->assertSame($location->getId(), $result->getLocation()->getId());
     }
 
     public function testPutNullValues(): void
@@ -223,7 +230,7 @@ class EventControllerTest extends SuluTestCase
                 'startDate' => null,
                 'endDate' => null,
                 'description' => null,
-                'location' => null,
+                'locationId' => null,
             ],
         );
 
@@ -241,7 +248,7 @@ class EventControllerTest extends SuluTestCase
         $this->assertNull($result['startDate']);
         $this->assertNull($result['endDate']);
         $this->assertSame($result['description'], '');
-        $this->assertNull($result['location']);
+        $this->assertNull($result['locationId']);
 
         $result = $this->findEventById($result['id'], 'de');
 

--- a/tests/Unit/Entity/EventTest.php
+++ b/tests/Unit/Entity/EventTest.php
@@ -6,19 +6,28 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Event;
 use App\Entity\EventTranslation;
+use App\Entity\Location;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 
 class EventTest extends TestCase
 {
     use ProphecyTrait;
 
+    /**
+     * @var ObjectProphecy<Location>
+     */
+    private ObjectProphecy $location;
+
     private Event $event;
 
     protected function setUp(): void
     {
+        $this->location = $this->prophesize(Location::class);
+
         $this->event = new Event();
         $this->event->setLocale('de');
     }
@@ -52,9 +61,12 @@ class EventTest extends TestCase
 
     public function testLocation(): void
     {
+        $this->location->getId()->willReturn(42);
+
         $this->assertNull($this->event->getLocation());
-        $this->assertSame($this->event, $this->event->setLocation('Amsterdam'));
-        $this->assertSame('Amsterdam', $this->event->getLocation());
+        $this->assertSame($this->event, $this->event->setLocation($this->location->reveal()));
+        $this->assertNotNull($this->event->getLocation());
+        $this->assertSame($this->location->reveal(), $this->event->getLocation());
     }
 
     public function testImage(): void

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -8,5 +8,6 @@
     "app.enable_event": "Veranstaltungen aktivieren",
     "app.enabled": "Aktiviert",
     "app.location": "Standort",
-    "app.locations": "Standorte"
+    "app.locations": "Standorte",
+    "app.location.no_selections": "Kein Standord ausgewählt"
 }

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -8,5 +8,6 @@
     "app.enable_event": "Enable event",
     "app.enabled": "Enabled",
     "app.location": "Location",
-    "app.locations": "Locations"
+    "app.locations": "Locations",
+    "app.location.no_selections": "No location selected"
 }


### PR DESCRIPTION
Add a association between events and locations
==============================================

Goal
----

After implementing the location management functionality in the Sulu administration interface, we want to add an 
association between the `Event` entity and the `Location` entity. With this assignment we are completing our goal of 
removing redundant location information inside of different events.

Steps
-----

* Add a many-to-one association between the `Event` entity and the `Location` entity
* Don't forget to update your database schema with `bin/adminconsole doctrine:schema:update --force`
* Serialize the id of the associated location of an event as `locationId` (will be used in the controller afterwards)
* Add the logic for setting and modifying the `locationId` property in your `src/Controller/EventController.php`
* Configure a new `single_location_selection` field type in your `config/packages/sulu_admin.yaml`
* Add a property `locationId` with the type `single_location_selection` to your `event_details` form
* Log into the admin UI with user "admin" and password "admin"
* Navigate to an event and select one of your locations

Hints
-----

* Run `bin/adminconsole doctrine:schema:validate`
* Run `bin/adminconsole debug:config sulu_admin field_type_options.single_selection` to get some insights on how to
 configure a single selection field type.

More Information
----------------

If you want to select a custom entity somewhere in your form, you need to use a respective field type for this 
property. To simplify this process for the developer, Sulu includes an abstract `selection` and `single_selection` 
field type. These abstract field types can be instantiated for your custom entity by providing respective 
`field_type_options` in the configuration of your application.

Links
-----

* Next assignment pull request: [12 - Add a location filter to the events overview page](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/pull/17)
* Source file of this assignment: [assignments/11.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/11.md)