### PR TITLE
12 - Add a location filter to the events overview page

### DIFF
--- a/config/templates/pages/event_overview.xml
+++ b/config/templates/pages/event_overview.xml
@@ -6,7 +6,7 @@
     <key>event_overview</key>
 
     <view>pages/event_overview</view>
-    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <controller>App\Controller\Website\EventOverviewController::indexAction</controller>
     <cacheLifetime>86400</cacheLifetime>
 
     <meta>
@@ -41,17 +41,6 @@
                 <title lang="en">Article</title>
                 <title lang="de">Artikel</title>
             </meta>
-        </property>
-
-        <property name="events" type="smart_content">
-            <meta>
-                <title lang="en">Events</title>
-                <title lang="de">Veranstaltungen</title>
-            </meta>
-
-            <params>
-                <param name="provider" value="events"/>
-            </params>
         </property>
     </properties>
 </template>

--- a/src/Controller/Website/EventOverviewController.php
+++ b/src/Controller/Website/EventOverviewController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Website;
+
+use App\Repository\EventRepository;
+use App\Repository\LocationRepository;
+use Sulu\Bundle\WebsiteBundle\Controller\DefaultController;
+use Sulu\Component\Content\Compat\StructureInterface;
+
+class EventOverviewController extends DefaultController
+{
+    protected function getAttributes($attributes, StructureInterface $structure = null, $preview = false)
+    {
+        /** @var EventRepository $eventRepository */
+        $eventRepository = $this->container->get(EventRepository::class);
+        /** @var LocationRepository $locationRepository */
+        $locationRepository = $this->container->get(LocationRepository::class);
+
+        $request = $this->getRequest();
+        $locationId = $request->query->get('location');
+
+        $attributes = parent::getAttributes($attributes, $structure, $preview);
+        $attributes['events'] = $eventRepository->filterByLocationId(
+            $locationId ? (int) $locationId : null,
+            $request->getLocale(),
+        );
+        $attributes['locations'] = $locationRepository->findAll();
+
+        return $attributes;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return \array_merge(
+            parent::getSubscribedServices(),
+            [
+                EventRepository::class,
+                LocationRepository::class,
+            ],
+        );
+    }
+}

--- a/src/DataFixtures/Document/DocumentFixture.php
+++ b/src/DataFixtures/Document/DocumentFixture.php
@@ -45,6 +45,12 @@ class DocumentFixture implements DocumentFixtureInterface
                 'structureType' => 'default',
                 'article' => '<p>This is a very good imprint :)</p>',
             ],
+            [
+                'title' => 'Events',
+                'navigationContexts' => ['main'],
+                'structureType' => 'event_overview',
+                'article' => '',
+            ],
         ];
 
         $pages = [];

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -65,6 +65,24 @@ class EventRepository extends ServiceEntityRepository implements DataProviderRep
     }
 
     /**
+     * @return Event[]
+     */
+    public function filterByLocationId(?int $locationId, string $locale): array
+    {
+        $criteria = ['enabled' => true];
+        if ($locationId) {
+            $criteria['location'] = $locationId;
+        }
+
+        $events = $this->findBy($criteria);
+        foreach ($events as $event) {
+            $event->setLocale($locale);
+        }
+
+        return $events;
+    }
+
+    /**
      * @param mixed[] $filters
      */
     public function findByFilters($filters, $page, $pageSize, $limit, $locale, $options = [])

--- a/templates/pages/event_overview.html.twig
+++ b/templates/pages/event_overview.html.twig
@@ -10,10 +10,31 @@
 
     <div class="container marketing">
         <div class="row">
-            {% for event in content.events %}
+            <form action="{{ sulu_content_path(content.url) }}" method="get" class="col-3">
+                <div class="form-group">
+                    <label for="location">Location</label>
+                    <select id="location" name="location" class="form-control">
+                        <option value>All ...</option>
+                        {% for location in locations %}
+                            <option value="{{ location.id }}"
+                                    {% if app.request.get('location') == location.id %}selected{% endif %}>
+                                {{ location.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <button type="submit" id="location_submit" class="btn btn-primary">Filter</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="container marketing mt-5">
+        <div class="row">
+            {% for event in events %}
                 <div class="col-lg-4 text-center">
-                    <h2 class="event-title">{{ event.resource.title }}</h2>
-                    <p>{{ event.resource.teaser }}</p>
+                    <h2 class="event-title">{{ event.title }}</h2>
+                    <p>{{ event.teaser }}</p>
                     <p>
                         <a class="btn btn-secondary" href="{{ path('app.event', {id: event.id}) }}" role="button">
                             View details »

--- a/tests/Functional/Pages/EventOverviewTest.php
+++ b/tests/Functional/Pages/EventOverviewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional\Pages;
 
 use App\Tests\Functional\Traits\EventTrait;
+use App\Tests\Functional\Traits\LocationTrait;
 use App\Tests\Functional\Traits\PageTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 class EventOverviewTest extends SuluTestCase
 {
     use EventTrait;
+    use LocationTrait;
     use PageTrait;
 
     private KernelBrowser $client;
@@ -23,6 +25,7 @@ class EventOverviewTest extends SuluTestCase
     {
         $this->client = $this->createWebsiteClient();
         $this->initPhpcr();
+        $this->purgeDatabase();
     }
 
     public function testEventOverview(): void
@@ -53,6 +56,56 @@ class EventOverviewTest extends SuluTestCase
         $this->assertStringContainsString($event1->getTitle() ?: '', $content);
         $this->assertNotNull($content = $crawler->filter('.event-title')->eq(1)->html());
         $this->assertStringContainsString($event2->getTitle() ?: '', $content);
+    }
+
+    public function testEventOverviewWithLocations(): void
+    {
+        $location1 = $this->createLocation('Dornbirn');
+        $location2 = $this->createLocation('Berlin');
+
+        $event1 = $this->createEvent('Sulu is awesome', 'en');
+        $event1->setLocation($location1);
+        $this->enableEvent($event1);
+        $event2 = $this->createEvent('Symfony Live is awesome', 'en');
+        $event2->setLocation($location2);
+        $this->enableEvent($event2);
+        $event3 = $this->createEvent('Disabled', 'en');
+
+        $this->createPage(
+            'event_overview',
+            'example',
+            [
+                'title' => 'Symfony Live',
+                'url' => '/events',
+                'published' => true,
+            ],
+        );
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/en/events');
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(2, $crawler->filter('.event-title'));
+        $this->assertNotNull($content = $crawler->filter('.event-title')->eq(0)->html());
+        $this->assertStringContainsString($event1->getTitle() ?: '', $content);
+        $this->assertNotNull($content = $crawler->filter('.event-title')->eq(1)->html());
+        $this->assertStringContainsString($event2->getTitle() ?: '', $content);
+
+        $form = $crawler->filter('#location_submit')->form(
+            [
+                'location' => $location1->getId(),
+            ],
+        );
+
+        $crawler = $this->client->submit($form);
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('.event-title'));
+        $this->assertNotNull($content = $crawler->filter('.event-title')->eq(0)->html());
+        $this->assertStringContainsString($event1->getTitle() ?: '', $content);
     }
 
     protected static function getDocumentManager(): DocumentManagerInterface


### PR DESCRIPTION
Add a location filter to the events overview page
=================================================

Goal
----

After adding an association between our `Location` entity and our `Event` entity in the last assignment, we can
now easily query events for a specific location. We want to make use of this by adding a location filter to the
events overview page of our website.

Steps
-----

* Create a new content controller `App\Controller\EventOverviewController`
* Remove the `events` property from the `event_overview` template
* Use the newly created `App\Controller\EventOverviewController` in your `event_overview` template
* Use the `EventRepository` to load events in your `EventOverviewController`
* Use the `LocationRepository` to load locations in your `EventOverviewController`
* Pass the loaded locations and events to your Twig template
* Render a form with a location dropdown in your `templates/events/index.html.twig`
* Add a `filterByLocationId` method to your `App\Repository\EventRepository`
* Call the `filterByLocationId` method with the submitted value in your `EventOverviewController`

Hints
-----


More Information
----------------


Links
-----

* Source file of this assignment: [assignments/12.md](https://github.com/sulu/sulu-workshop-symfony-live-berlin-2019/blob/master/assignments/12.md)